### PR TITLE
feat: fixing microsdeck dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@cebbinghaus/microsdeck": "0.9.6-3b08037",
+    "@cebbinghaus/microsdeck": "0.9.7-ea88921",
     "mobx": "^5.15.7",
     "react-icons": "^4.10.1",
     "react-virtualized-auto-sizer": "^1.0.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabmaster",
-  "version": "2.1.1",
+  "version": "2.0.0",
   "description": "Gives you full control over your Steam library! Support for customizing, adding, and hiding Library Tabs.",
   "scripts": {
     "build": "shx rm -rf dist && rollup -c",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@cebbinghaus/microsdeck':
-    specifier: 0.9.6-3b08037
-    version: 0.9.6-3b08037
+    specifier: 0.9.7-ea88921
+    version: 0.9.7-ea88921
   mobx:
     specifier: ^5.15.7
     version: 5.15.7
@@ -119,8 +119,8 @@ packages:
       regenerator-runtime: 0.14.0
     dev: false
 
-  /@cebbinghaus/microsdeck@0.9.6-3b08037:
-    resolution: {integrity: sha512-YNdue4ZwRbHmzkYLEVPQd2k1DTPN2IZe8YHUHy0GTz5KRQlNmgOHQesWZGrzU9GOPnb6dI9Ps2RqmGJcWVXfVw==}
+  /@cebbinghaus/microsdeck@0.9.7-ea88921:
+    resolution: {integrity: sha512-Z5O6gWQCTaqCVogrKNzt1YtYfTyxu9J5hifKx+3fWuLmYt+wwdmyK67xi8wnBdOCDgSMFGWmh91wLiS2KdfrMg==}
     dependencies:
       typescript: 4.9.5
     dev: false

--- a/src/components/filters/FilterOptions.tsx
+++ b/src/components/filters/FilterOptions.tsx
@@ -749,7 +749,7 @@ const OnCardFilterOptions: VFC<FilterOptionsProps<'on card'>> = ({ index, setCon
 
   return (
     <Field
-      label="Selected Collection"
+      label="MicroSD Card"
       description={<Dropdown rgOptions={dropdownOptions} selectedOption={currentOption} onChange={onChange} />}
     />
   );

--- a/src/components/filters/FilterOptions.tsx
+++ b/src/components/filters/FilterOptions.tsx
@@ -722,26 +722,28 @@ const StreamableFilterOptions: VFC<FilterOptionsProps<'streamable'>> = ({ index,
   );
 };
 
-/**
- * The options for On Card Visbility
- */
-const OnCardFilterOptions: VFC<FilterOptionsProps<'on card'>> = ({ index, setContainingGroupFilters, filter, containingGroupFilters }) => {
-  const cardsAndGames = MicroSDeck?.CardsAndGames || [];
-  
-  if (!cardsAndGames.length) {
-    return (
-      <div>
-        No Cards have been registered yet...
-      </div>
-    )
-  }
+const CurrentlyInsertedCardOption: DropdownOption = {
+  label: "Inserted Card",
+  data: undefined,
+} 
 
-  const currentOption = filter.params.cardId || cardsAndGames[0][0].uid;
-  const dropdownOptions: DropdownOption[] = cardsAndGames.map(([card]) => { return { label: card.name || "Unamed Card", data: card.uid } });
+/**
+ * The options for SD Card Visbility
+ */
+const SDCardFilterOptions: VFC<FilterOptionsProps<'sd card'>> = ({ index, setContainingGroupFilters, filter, containingGroupFilters }) => {
+  const cardsAndGames = MicroSDeck?.CardsAndGames || [];  
+  const dropdownOptions: DropdownOption[] = [CurrentlyInsertedCardOption];
+
+  dropdownOptions.push({
+    label: "Specific Card",
+    options: cardsAndGames.map(([card]) => { return { label: card.name || "Unamed Card", data: card.uid } })
+  })
+
+  const currentOption = filter.params.card;
 
   function onChange({data}: SingleDropdownOption) {
     const updatedFilter = { ...filter };
-    updatedFilter.params.cardId = data;
+    updatedFilter.params.card = data;
     const updatedFilters = [...containingGroupFilters];
     updatedFilters[index] = updatedFilter;
     setContainingGroupFilters(updatedFilters);
@@ -795,8 +797,8 @@ export const FilterOptions: VFC<FilterOptionsProps<FilterType>> = ({ index, filt
         return <DemoFilterOptions index={index} filter={filter as TabFilterSettings<'demo'>} containingGroupFilters={containingGroupFilters} setContainingGroupFilters={setContainingGroupFilters} />;
       case "streamable":
         return <StreamableFilterOptions index={index} filter={filter as TabFilterSettings<'streamable'>} containingGroupFilters={containingGroupFilters} setContainingGroupFilters={setContainingGroupFilters} />;
-      case "on card":
-        return <OnCardFilterOptions index={index} filter={filter as TabFilterSettings<'on card'>} containingGroupFilters={containingGroupFilters} setContainingGroupFilters={setContainingGroupFilters} />;
+      case "sd card":
+        return <SDCardFilterOptions index={index} filter={filter as TabFilterSettings<'sd card'>} containingGroupFilters={containingGroupFilters} setContainingGroupFilters={setContainingGroupFilters} />;
       default:
         return <Fragment />;
     }

--- a/src/components/filters/Filters.ts
+++ b/src/components/filters/Filters.ts
@@ -66,6 +66,30 @@ export type TabFilterSettings<T extends FilterType> = {
 type FilterFunction = (params: FilterParams<FilterType>, appOverview: SteamAppOverview) => boolean;
 
 /**
+ * Set the Description for a filter type here
+ */
+export const FilterDescriptions: { [filterType in FilterType]: string } = {
+  collection: "Selects apps that are in a certain Steam Collection.",
+  installed: "Selects apps that are installed/uninstalled.",
+  regex: "Selects apps whose titles match a regular expression.",
+  friends: "Selects apps that are also owned by friends.",
+  tags: "Selects apps that have specific community tags.",
+  whitelist: "Selects apps that are added to the list.",
+  blacklist: "Selects apps that are not added to the list.",
+  merge: "Selects apps that pass a subgroup of filters.",
+  platform: "Selects Steam or non-Steam apps.",
+  "deck compatibility": "Selects apps that have a specific Steam Deck compatibilty status.",
+  "review score": "Selects apps based on their metacritic/steam review score.",
+  "time played": "Selects apps based on your play time.",
+  "size on disk": "Selects apps based on their install size.",
+  "release date": "Selects apps based on their release date.",
+  "last played": "Selects apps based on when they were last played.",
+  demo: "Selects apps that are/aren't demos.",
+  streamable: "Selects apps that can/can't be streamed from another computer.",
+  "sd card": "Selects apps that are present on the inserted/ specific MicroSD Card",
+}
+
+/**
  * Define the deafult params for a filter type here
  * Checking and settings defaults in component is unnecessary
  */
@@ -88,8 +112,29 @@ export const FilterDefaultParams: { [key in FilterType]: FilterParams<key> } = {
   "demo": { isDemo: true },
   "streamable": { isStreamable: true },
   "sd card": { cardId: 'inserted' },
-
 };
+
+/**
+ * Which plugin needs to be installed for this filter to be active
+ */
+export const FilterPluginSource: { [key in FilterType]?: string } = {
+  "sd card": "MicroSDeck",
+};
+
+/**
+ * Whether the filter is disabled (cannot be selected or run)
+ * @param filter The filter to check.
+ * @returns True if the filter should be considered disabled
+ */
+export function isFilterDisabled(filter: FilterType): boolean {
+  switch (filter) {
+    case "sd card":
+      return !MicroSDeck
+    default:
+      return false;
+  }
+}
+
 
 /**
  * Whether the filter should have an invert option.

--- a/src/components/filters/Filters.ts
+++ b/src/components/filters/Filters.ts
@@ -7,6 +7,8 @@ export type TimeUnit = 'minutes' | 'hours' | 'days';
 export type ThresholdCondition = 'above' | 'below';
 export type ReviewScoreType = 'metacritic' | 'steampercent';
 
+export type PluginSources = "MicroSDeck";
+
 type CollectionFilterParams = {
   id: SteamCollection['id'],
   /**
@@ -117,7 +119,7 @@ export const FilterDefaultParams: { [key in FilterType]: FilterParams<key> } = {
 /**
  * Which plugin needs to be installed for this filter to be active
  */
-export const FilterPluginSource: { [key in FilterType]?: string } = {
+export const FilterPluginSource: { [key in FilterType]?: PluginSources } = {
   "sd card": "MicroSDeck",
 };
 

--- a/src/components/menus/PresetMenu.tsx
+++ b/src/components/menus/PresetMenu.tsx
@@ -1,6 +1,6 @@
 import { Menu, MenuGroup, MenuItem } from 'decky-frontend-lib';
 import { VFC, Fragment } from 'react';
-import { PresetName, presetKeys } from '../../presets/presets';
+import { CanPresetBeUsed, presetKeys } from '../../presets/presets';
 import { capitalizeEachWord } from '../../lib/Utils';
 import { TabMasterManager } from '../../state/TabMasterManager';
 import { compatCategoryToLabel } from '../filters/Filters';
@@ -26,8 +26,7 @@ export const PresetMenuItems: VFC<PresetMenuItemsProps> = ({ tabMasterManager })
   }
 
   return <>
-    {presetKeys.map(name => {
-      const presetName = name as PresetName;
+    {presetKeys.filter(CanPresetBeUsed).map(presetName => {
       switch (presetName) {
         case 'collection':
           return (

--- a/src/components/styles/FilterSelectionStyles.tsx
+++ b/src/components/styles/FilterSelectionStyles.tsx
@@ -118,6 +118,10 @@ export const FilterSelectStyles: VFC<{}> = ({}) => {
         text-align: initial;
       }
 
+      .tab-master-filter-select .entry-disabled {
+        color: #92939B;
+      }
+
       .tab-master-filter-select .entry-desc {
         font-size: 16px;
         text-align: initial;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,12 +38,12 @@ import { LogController } from "./lib/controllers/LogController";
 import { DocPage } from "./components/docs/DocsPage";
 import { IncludeCategories } from "./lib/Utils";
 import { PresetMenu } from './components/menus/PresetMenu';
-import { MicroSDeckManager } from "@cebbinghaus/microsdeck";
+import { MicroSDeck } from "@cebbinghaus/microsdeck";
 import { MicroSDeckInterop } from './lib/controllers/MicroSDeckInterop';
 
 declare global {
   let DeckyPluginLoader: { pluginReloadQueue: { name: string; version?: string; }[]; };
-  var MicroSDeck: MicroSDeckManager | undefined;
+  var MicroSDeck: MicroSDeck | undefined;
   var SteamClient: SteamClient;
   let collectionStore: CollectionStore;
   let appStore: AppStore;

--- a/src/lib/controllers/MicroSDeckInterop.ts
+++ b/src/lib/controllers/MicroSDeckInterop.ts
@@ -1,6 +1,6 @@
 import { sleep } from 'decky-frontend-lib';
 import { LogController } from './LogController';
-import { MicroSDeckManager } from '@cebbinghaus/microsdeck';
+import { MicroSDeck as MicroSDeckManager } from '@cebbinghaus/microsdeck';
 
 export class MicroSDeckInterop {
   public static state: 'not installed' | 'version too low' | 'version too high' | 'good' = 'not installed';

--- a/src/presets/presets.ts
+++ b/src/presets/presets.ts
@@ -74,14 +74,31 @@ const presetDefines = {
       filtersMode: 'or',
       categoriesToInclude: IncludeCategories.software
     };
+  },
+  'MicroSD Card': () => {
+    return {
+      filters: [
+        { type: 'sd card', inverted: false, params: { card: undefined } },
+      ],
+      filtersMode: 'or',
+      categoriesToInclude: IncludeCategories.games
+    };
   }
-
 };
 
 export type PresetName = keyof typeof presetDefines;
 export type PresetOptions<Name extends keyof typeof presetDefines> = Parameters<typeof presetDefines[Name]>;
 
-export const presetKeys = Object.keys(presetDefines);
+export const presetKeys = Object.keys(presetDefines) as PresetName[];
+
+export function CanPresetBeUsed(presetKey: PresetName): boolean {
+  switch (presetKey) {
+    case "MicroSD Card":
+      return !!MicroSDeck;
+    default:
+      return true;
+  }
+}
 
 export function getPreset<Name extends PresetName>(presetName: Name, ...presetOptions: PresetOptions<Name>) {
   return (presetDefines[presetName] as (...options: any[]) => TabPreset)(...presetOptions);

--- a/src/state/TabMasterManager.tsx
+++ b/src/state/TabMasterManager.tsx
@@ -75,7 +75,7 @@ export class TabMasterManager {
   }
 
   private initMicroSDeck(): void {
-    if(MicroSDeck?.Enabled) {
+    if (MicroSDeck?.Enabled) {
       LogController.log(`Initializing MicroSDeck listener`);
 
       // make sure we unsubscribe first
@@ -124,7 +124,7 @@ export class TabMasterManager {
     this.tagsReaction = reaction(() => appStore.m_mapStoreTagLocalization, this.storeTagReaction.bind(this), { delay: 50 });
 
     this.storeTagReaction(appStore.m_mapStoreTagLocalization);
-    
+
     this.initMicroSDeck();
   }
 
@@ -489,8 +489,8 @@ export class TabMasterManager {
     this.updateAndSave();
   }
 
-  createPresetTab<Name extends PresetName>(presetName: Name, tabTitle: string, ...options: PresetOptions<Name>){
-    const { filters, filtersMode, categoriesToInclude} = getPreset(presetName, ...options);
+  createPresetTab<Name extends PresetName>(presetName: Name, tabTitle: string, ...options: PresetOptions<Name>) {
+    const { filters, filtersMode, categoriesToInclude } = getPreset(presetName, ...options);
     this.createCustomTab(tabTitle, this.visibleTabsList.length, filters, filtersMode, categoriesToInclude);
   }
 
@@ -531,7 +531,9 @@ export class TabMasterManager {
           const filter = tabSetting.filters[i];
           const filterValidated = validateFilter(filter);
 
-          if (!filterValidated.passed) {
+          if (!filterValidated) {
+            tabErroredFilters.push({ filterIdx: i, errors: [`Filter "${filter.type}" cannot be validated. It has likely been removed.`] });
+          } else if (!filterValidated.passed) {
             let entry: FilterErrorEntry = {
               filterIdx: i,
               errors: filterValidated.errors
@@ -720,13 +722,13 @@ export class TabMasterManager {
 
     this.tabsMap.forEach(tabContainer => {
       const tabSettings: TabSettings = tabContainer.filters ?
-        { 
-          id: tabContainer.id, 
-          title: tabContainer.title, 
-          position: tabContainer.position, 
-          filters: tabContainer.filters, 
-          filtersMode: (tabContainer as CustomTabContainer).filtersMode, 
-          categoriesToInclude: (tabContainer as CustomTabContainer).categoriesToInclude 
+        {
+          id: tabContainer.id,
+          title: tabContainer.title,
+          position: tabContainer.position,
+          filters: tabContainer.filters,
+          filtersMode: (tabContainer as CustomTabContainer).filtersMode,
+          categoriesToInclude: (tabContainer as CustomTabContainer).categoriesToInclude
         }
         : tabContainer;
 

--- a/src/state/TabMasterManager.tsx
+++ b/src/state/TabMasterManager.tsx
@@ -74,6 +74,21 @@ export class TabMasterManager {
     this.tabsMap = new Map<string, TabContainer>();
   }
 
+  private initMicroSDeck(): void {
+    if(MicroSDeck?.Enabled) {
+      LogController.log(`Initializing MicroSDeck listener`);
+
+      // make sure we unsubscribe first
+      MicroSDeck.eventBus.removeEventListener("change", this.microSDeckEvent.bind(this));
+      MicroSDeck.eventBus.addEventListener("change", this.microSDeckEvent.bind(this));
+    }
+  }
+
+  private microSDeckEvent(e: Event) {
+    LogController.log("Recieved Update", e);
+    this.rebuildCustomTabsOnCollectionChange();
+  }
+
   private initReactions(): void {
     //* subscribe to changes to all games
     this.allGamesReaction = reaction(() => collectionStore.GetCollection("type-games").allApps, this.rebuildCustomTabsOnCollectionChange.bind(this), { delay: 600 });
@@ -109,6 +124,8 @@ export class TabMasterManager {
     this.tagsReaction = reaction(() => appStore.m_mapStoreTagLocalization, this.storeTagReaction.bind(this), { delay: 50 });
 
     this.storeTagReaction(appStore.m_mapStoreTagLocalization);
+    
+    this.initMicroSDeck();
   }
 
   /**


### PR DESCRIPTION
This PR cleans up some of the previous dependencies on MicroSDeck to make fallback behavior cleaner for when MicroSDeck is not installed.

Goals: 
- [x] Grayed out MicroSDeck specific filters when not installed
- [ ] Invalidate all existing filters if MicroSDeck cannot be found
- [ ] Ensure event subscriber is triggered even if MicroSDeck is installed post TabMaster
- [ ] Clean up after myself.