### PR TITLE
fix: fixed microsdeck qam check

### DIFF
--- a/src/components/QuickAccessContent.tsx
+++ b/src/components/QuickAccessContent.tsx
@@ -46,7 +46,7 @@ export const QuickAccessContent: VFC<{}> = ({ }) => {
   const { visibleTabsList, hiddenTabsList, tabsMap, tabMasterManager } = useTabMasterContext();
 
   const microSDeckInstallState = MicroSDeckInterop.getInstallState();
-  const isMicroSDeckInstalled = microSDeckInstallState === MicroSDeckInstallState['good'];
+  const isMicroSDeckInstalled = microSDeckInstallState === MicroSDeckInstallState.VERSION_COMPATIBLE;
   const hasSdTabs = !!visibleTabsList.find(tabContainer => (tabContainer as CustomTabContainer).dependsOnMicroSDeck);
 
   function TabEntryInteractables({ entry }: TabEntryInteractablesProps) {


### PR DESCRIPTION
This fixes the bug shown in the attached image, where the install state check for MicroSDeck passes, but the QAM check fails because it looks for the old `['good']` Enum state.
![download](https://github.com/Tormak9970/TabMaster/assets/1066726/05400044-5a50-47bd-afd2-1617adabf113)
