### PR TITLE
chore: clickable table-of-contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ Available Filters:
 - **Time Played** - Selects apps that have a play time greater/less than the provided time.
 - **Size on Disk** - Selects apps that have an install size greater/less than the provided size.
 - **Release Date** - Selects apps that were released before/after the provided date.
+- **Purchase Date** - Selects apps that were purchased before/after the provided date.
 - **Last Played** - Selects apps that were last played before/after the provided date.
+- **Family Sharing** - Selects apps that are/aren't from a family member.
 - **Demo** - Selects apps that are/aren't demos.
 - **Coming Soon** - Selects apps that are/aren't coming soon.
 - **Streamable** - Selects apps that can/can't be streamed from another computer.
 - **Steam Features** - Selects apps that support specific Steam Features.
+- **Achievements** - Selects apps based on their achievement completion.
 - **MicroSD Card** - Selects apps that are present on the inserted/specific MicroSD Card.
 - **Install Folder** - Selects apps that are present on the specific install folder.
 

--- a/src/components/docs/plugin-docs/Filters.md
+++ b/src/components/docs/plugin-docs/Filters.md
@@ -2,32 +2,34 @@
 
 ### Table of Contents
 
-- Overview
-- Inverting Filters
-- Available Filters
-    - Collection
-    - Installed
-    - Friends
-    - Community Tags
-    - Whitelist
-    - Blacklist
-    - Platform
-    - Deck Compatibility
-    - SteamOS Compatibility
-    - Regex
-    - Merge
-    - Platform
-    - Deck Compatability
-    - Review Score
-    - Time Played
-    - Size on Disk
-    - Release Date
-    - Last Played
-    - Demo
-    - Streamable
-    - Steam Features
-    - Achievements
-    - MicroSD Card (Requires MicroSDeck)
+- [Overview](#overview)
+- [Inverting Filters](#inverting-filters)
+- [Available Filters](#available-filters)
+    - [Collection](#collection)
+    - [Installed](#installed)
+    - [Regex](#regex)
+    - [Friends](#friends)
+    - [Community Tags](#community-tags)
+    - [Whitelist](#whitelist)
+    - [Blacklist](#blacklist)
+    - [Merge](#merge)
+    - [Platform](#platform)
+    - [Deck Compatibility](#deck-compatibility)
+    - [SteamOS Ccompatibility](#steamos-ccompatibility)
+    - [Review Score](#review-score)
+    - [Time Played](#time-played)
+    - [Size on Disk](#size-on-disk)
+    - [Release Date](#release-date)
+    - [Purchase Date](#purchase-date)
+    - [Last Played](#last-played)
+    - [Family Sharing](#family-sharing)
+    - [Demo](#demo)
+    - [Coming Soon](#coming-soon)
+    - [Streamable](#streamable)
+    - [Steam Features](#steam-features)
+    - [Achievements](#achievements)
+    - [MicroSD Card](#microsd-card)
+    - [Install Folder](#install-folder)
 
 <br/>
 
@@ -383,7 +385,10 @@ Filters apps based on their achievement completion percentage or count.
 
 <br/>
 
-#### MicroSD Card (Requires MicroSDeck)
+#### MicroSD Card
+
+**Note:**<br/>
+Requires MicroSDeck.
 
 **Options:**<br/>
 `MicroSD card` - The MicroSD card to use (if none are showing up, make sure they are showing up in MicroSDeck).

--- a/src/components/docs/plugin-docs/Filters.md
+++ b/src/components/docs/plugin-docs/Filters.md
@@ -410,4 +410,6 @@ Filters apps based on if they are installed in the specified Steam Install Folde
 
 <br/>
 
-###### © Travis Lane (Tormak), Jessebofill
+---
+
+© Travis Lane (Tormak), Jessebofill

--- a/src/components/docs/plugin-docs/Filters.md
+++ b/src/components/docs/plugin-docs/Filters.md
@@ -73,6 +73,24 @@ Filters apps based on their install state.
 
 <br/>
 
+#### Regex
+
+**Options:**<br/>
+`regex` - The regular expression to use.
+`inverted` - If true, inverts the filtered apps (exclued apps are now included, and vis versa).
+
+**Behavior:**<br/>
+Filters apps by testing if their title matches a regular expression .
+
+**Tip:**<br/>
+Regular expressions can seem daunting and confusing. You can test yours before hand by looking up a "Regex Tester" website.<br/>
+Also, by typing a phrase like "Zelda" into the regex field, it will include any game with that phrase in its title.
+
+**Example:**<br/>
+<img title="Regex Example" src="https://raw.githubusercontent.com/tormak9970/TabMaster/master/assets/filters/docs_regex-example.png" />
+
+<br/>
+
 #### Friends
 
 **Options:**<br/>
@@ -133,24 +151,6 @@ Filters apps by if they are not in the list.
 
 <br/>
 
-#### Regex
-
-**Options:**<br/>
-`regex` - The regular expression to use.
-`inverted` - If true, inverts the filtered apps (exclued apps are now included, and vis versa).
-
-**Behavior:**<br/>
-Filters apps by testing if their title matches a regular expression .
-
-**Tip:**<br/>
-Regular expressions can seem daunting and confusing. You can test yours before hand by looking up a "Regex Tester" website.<br/>
-Also, by typing a phrase like "Zelda" into the regex field, it will include any game with that phrase in its title.
-
-**Example:**<br/>
-<img title="Regex Example" src="https://raw.githubusercontent.com/tormak9970/TabMaster/master/assets/filters/docs_regex-example.png" />
-
-<br/>
-
 #### Merge
 
 **Options:**<br/>
@@ -182,28 +182,28 @@ Filters apps based on their platform.
 
 <br/>
 
-#### Deck Compatability
+#### Deck Compatibility
 
 **Options:**<br/>
-`compatability level` - The desired compatability level, either "Verified", "Playable", "Unsupported", or "Unkown".
+`ccompatibility level` - The desired ccompatibility level, either "Verified", "Playable", "Unsupported", or "Unkown".
 `inverted` - If true, inverts the filtered apps (exclued apps are now included, and vis versa).
 
 **Behavior:**<br/>
-Filters apps based on their Steam Deck compatability.
+Filters apps based on their Steam Deck ccompatibility.
 
 **Example:**<br/>
 <img title="Deck Compat Example" src="https://raw.githubusercontent.com/tormak9970/TabMaster/master/assets/filters/docs_deck-compat-example.png" />
 
 <br/>
 
-#### SteamOS Compatability
+#### SteamOS Ccompatibility
 
 **Options:**<br/>
-`compatability level` - The desired compatability level, either "Compatible", "Unsupported", or "Unkown".
+`ccompatibility level` - The desired ccompatibility level, either "Compatible", "Unsupported", or "Unkown".
 `inverted` - If true, inverts the filtered apps (exclued apps are now included, and vis versa).
 
 **Behavior:**<br/>
-Filters apps based on their SteamOS Deck compatability.
+Filters apps based on their SteamOS Deck ccompatibility.
 
 **Example:**<br/>
 <img title="SteamOS Compat Example" src="https://raw.githubusercontent.com/tormak9970/TabMaster/master/assets/filters/docs_steamos-compat-example.png" />

--- a/src/components/docs/plugin-docs/Filters.md
+++ b/src/components/docs/plugin-docs/Filters.md
@@ -206,7 +206,7 @@ Filters apps based on their Steam Deck compatability.
 Filters apps based on their SteamOS Deck compatability.
 
 **Example:**<br/>
-<img title="SteamOS Compat Example" src="https://raw.githubusercontent.com/tormak9970/TabMaster/master/assets/filters/docs_SteamOS-compat-example.png" />
+<img title="SteamOS Compat Example" src="https://raw.githubusercontent.com/tormak9970/TabMaster/master/assets/filters/docs_steamos-compat-example.png" />
 
 <br/>
 

--- a/src/components/docs/plugin-docs/Overview.md
+++ b/src/components/docs/plugin-docs/Overview.md
@@ -27,4 +27,6 @@ These docs serve as a reference for questions you may have, and a guide for help
 <br/>
 
 
-###### © Travis Lane (Tormak), Jessebofill
+---
+
+© Travis Lane (Tormak), Jessebofill

--- a/src/components/docs/plugin-docs/Overview.md
+++ b/src/components/docs/plugin-docs/Overview.md
@@ -13,6 +13,7 @@ These docs serve as a reference for questions you may have, and a guide for help
 
 
 ### Table of Contents
+
 * Overview
   * General overview of the plugin and docs. **You are here**
 * Tabs

--- a/src/components/docs/plugin-docs/Tab_Profiles.md
+++ b/src/components/docs/plugin-docs/Tab_Profiles.md
@@ -55,4 +55,6 @@ Decide you don't like a profile anymore? Well deleting it is easy too! Just open
 <br/>
 
 
-###### © Travis Lane (Tormak), Jessebofill
+---
+
+© Travis Lane (Tormak), Jessebofill

--- a/src/components/docs/plugin-docs/Tab_Profiles.md
+++ b/src/components/docs/plugin-docs/Tab_Profiles.md
@@ -1,12 +1,14 @@
 ## Tab Profiles
 
 ### Table of Contents
- - Overview
- - The Tab Profiles Context Menu
- - Creating Profiles
- - Applying Profiles
- - Overwriting Profiles
- - Deleting Profiles
+
+- [Table of Contents](#table-of-contents)
+- [Overview](#overview)
+- [The Tab Profiles Context Menu](#the-tab-profiles-context-menu)
+- [Creating Profiles](#creating-profiles)
+- [Applying Profiles](#applying-profiles)
+- [Overwriting Profiles](#overwriting-profiles)
+- [Deleting Profiles](#deleting-profiles)
 
 <br/>
 

--- a/src/components/docs/plugin-docs/Tab_Profiles.md
+++ b/src/components/docs/plugin-docs/Tab_Profiles.md
@@ -14,7 +14,7 @@
 ### Overview
 Here you can find everything about Tab Profiles, including adding, applying, overwriting, and deleting them. To get started, use the button pictured below or the TabMaster context menu to open the Tab Profiles Menu.
 
-<img title="Managing Tab Profiles" src="https://raw.githubusercontent.com/tormak9970/TabMaster/master/assets/docs_managing-tab-profiles.png" />
+<img title="Managing Tab Profiles" src="https://raw.githubusercontent.com/tormak9970/TabMaster/master/assets/tab-profiles/docs_managing-tab-profiles.png" />
 
 <br/>
 
@@ -42,7 +42,7 @@ Overwriting a profile is easy! Just open the Tab Profiles menu, and navigate to 
 
 
 ### Overwriting Profiles
-<img title="Overwriting Tab Profiles" src="https://raw.githubusercontent.com/tormak9970/TabMaster/master/assets/tab-profiles/docs_coverwriting-tab-profiles.png" />
+<img title="Overwriting Tab Profiles" src="https://raw.githubusercontent.com/tormak9970/TabMaster/master/assets/tab-profiles/docs_overwriting-tab-profiles.png" />
 <br/>
 Made a mistake while making a profile, or just decide something needed to change? Well its easy to overwrite profiles, just open the profiles menu and navigate to the profile you want to delete and click "Y". A window will show up comparing what's in the profile, to what you're overwriting it with, allowing you to see the changes that will be made. Simply confirm here, and the profile will be overwritten.
 

--- a/src/components/docs/plugin-docs/Tabs.md
+++ b/src/components/docs/plugin-docs/Tabs.md
@@ -105,4 +105,6 @@ Tabs can be shared with other users on your device. Simply toggle "Other users c
 <br/>
 
 
-###### © Travis Lane (Tormak), Jessebofill
+---
+
+© Travis Lane (Tormak), Jessebofill

--- a/src/components/docs/plugin-docs/Tabs.md
+++ b/src/components/docs/plugin-docs/Tabs.md
@@ -1,19 +1,20 @@
 ## Tabs
 
 ### Table of Contents
- - Overview
- - Custom vs. Default
- - The TabMaster Context Menu
- - Quick Tabs
- - Adding Tabs
-   - New Tab Options
- - Editing Tabs
-   - Changing Tabs
-   - Reordering Tabs
-   - Hiding Tabs
- - Duplicating Tabs
- - Removing Tabs
- - Sharing Tabs
+
+- [Overview](#overview)
+- [Custom vs. Default](#custom-vs-default)
+- [The TabMaster Context Menu](#the-tabmaster-context-menu)
+- [Quick Tabs](#quick-tabs)
+- [Adding Tabs](#adding-tabs)
+    - [Options:](#options)
+- [Editing Tabs](#editing-tabs)
+    - [Changing Tabs (Custom Tabs Only)](#changing-tabs-custom-tabs-only)
+    - [Reordering Tabs](#reordering-tabs)
+    - [Hiding Tabs](#hiding-tabs)
+- [Duplicating Tabs](#duplicating-tabs)
+- [Removing Tabs (Custom Tabs Only)](#removing-tabs-custom-tabs-only)
+- [Sharing Tabs](#sharing-tabs)
 
 <br/>
 

--- a/src/components/docs/plugin-docs/The_Fix_System.md
+++ b/src/components/docs/plugin-docs/The_Fix_System.md
@@ -10,7 +10,8 @@
 
 
 ### What is the Fix System?
-The fix system is TabMaster's solution for tough situations, where the plugin is unable to automatically fix issues. In these cases, we thought it best to leave the decision of what to do up to you, the user.<br/>
+The fix system is TabMaster's solution for tough situations, where the plugin is unable to automatically fix issues. In these cases, we thought it best to leave the decision of what to do up to you, the user.
+
 **Causes:**
  - Deleting a collection used as a filter
 
@@ -18,7 +19,8 @@ The fix system is TabMaster's solution for tough situations, where the plugin is
 
 
 ### How to use the Fix System
-We've tried to make this system as simple and easy to use as possible. When an issue that would break TabMaster occurs, it will show the fix system window, and let you know what went wrong.<br/>
+We've tried to make this system as simple and easy to use as possible. When an issue that would break TabMaster occurs, it will show the fix system window, and let you know what went wrong.
+
 **Note!**: You need to fix the issue! If you don't TabMaster will not work, and will show the fix system each time you log in until you fix it!
 
 #### Fixing a Filter

--- a/src/components/docs/plugin-docs/The_Fix_System.md
+++ b/src/components/docs/plugin-docs/The_Fix_System.md
@@ -1,10 +1,11 @@
 ## The Fix System
 
-### Table of Contes
-- What is the Fix System?
-- How to use the Fix System
-  - Fixing a Filter
-  - Fixing a Filter in a Group
+### Table of Contents
+
+- [What is the Fix System?](#what-is-the-fix-system)
+- [How to use the Fix System](#how-to-use-the-fix-system)
+    - [Fixing a Filter](#fixing-a-filter)
+    - [Fixing a Filter in a Group](#fixing-a-filter-in-a-group)
 
 <br/>
 

--- a/src/components/docs/plugin-docs/The_Fix_System.md
+++ b/src/components/docs/plugin-docs/The_Fix_System.md
@@ -38,4 +38,6 @@ In order to fix a filter in a merge group, you need to open the group. Once done
 <br/>
 
 
-###### © Travis Lane (Tormak), Jessebofill
+---
+
+© Travis Lane (Tormak), Jessebofill


### PR DESCRIPTION
NOTE! This PR should be applied AFTER #327. To avoid merge conflicts, it includes commits from that PR.

---

They were auto-generated with
<https://github.com/ekalinin/github-markdown-toc>

The old TOC wasn't very helpful, and even had repeated entries.

As a side-effect, thinking about good URLs, I've changed the heading
from `MicroSD Card (Requires MicroSDeck)` to just `MicroSD Card`, as
that generates a `#microsd-card` anchor.

---

Please note: I have NOT built the plugin, and I have NOT tested these changes inside Decky. Please review them yourself before merging. I don't know how links will be have in the built-in TabMaster docs renderer.