### PR TITLE
fix: restore from backup correctly parses settings file 

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ class Plugin:
 
     try:
       with open(source_path, 'r', encoding='utf-8') as settings_file:
-        data = json.loads(settings_file)
+        data = json.load(settings_file)
         self.settings.settings = data
         self.settings.commit()
         self.save_on_shutdown = False


### PR DESCRIPTION
## Summary
`restore_settings` passed the open file handle to `json.loads`, which expects a string, so it always threw and the bare `except` silently returned failure. Switched to `json.load`.

Closes issue #325

## Test Plan
- Navigate to the Tabmaster plugin
- Click on Restore Settings
- Select the settings.json
- Verify configured tabs in `settings.json` is properly loaded in Tabmaster