### PR TITLE
fix: action buttons overflow

### DIFF
--- a/src/components/qam/QuickAccessContent.tsx
+++ b/src/components/qam/QuickAccessContent.tsx
@@ -158,7 +158,7 @@ export const QuickAccessContent: VFC<{}> = ({}) => {
                     <div style={{ margin: '5px', marginTop: '0px' }}>
                         Here you can add, re-order, or remove tabs from the library.
                     </div>
-                    <Field className='no-sep'>
+                    <Field childrenContainerWidth='max' className='no-sep'>
                         <Focusable style={{ width: '100%', display: 'flex' }}>
                             <Focusable className='add-tab-btn'>
                                 <DialogButton


### PR DESCRIPTION
## Summary
The QAM action buttons (Add Tab, Add Quick Tab, View Shared Tabs, Restore, Backup) overflowed past the right edge of the panel.

<img width="3024" height="1888" alt="CleanShot 2026-07-25 at 01 40 24@2x" src="https://github.com/user-attachments/assets/c3b1f371-11f5-4d4d-8f1f-fc986e69c20d" />

<img width="3024" height="1888" alt="CleanShot 2026-07-25 at 01 40 33@2x" src="https://github.com/user-attachments/assets/39e64983-d186-41db-b0cc-cfbe6b657fc9" />

**Fix:** Passing `childrenContainerWidth='max'` lifts the cap at the source (same prop already used in `FiltersPanel`), so the buttons fit regardless of count.


## Test Plan
- Navigate to the Tabmaster plugin
- Verify the action buttons are not overflowing

<img width="3024" height="1888" alt="CleanShot 2026-07-25 at 02 02 26@2x" src="https://github.com/user-attachments/assets/356fd0c7-b962-426e-b161-72c1eecddcec" />

